### PR TITLE
Fix cast exception due to wrong root

### DIFF
--- a/FakeSearchView/app/src/main/java/com/github/leonardoxh/fakesearchview/FakeSearchView.java
+++ b/FakeSearchView/app/src/main/java/com/github/leonardoxh/fakesearchview/FakeSearchView.java
@@ -119,8 +119,8 @@ public class FakeSearchView extends FrameLayout implements TextWatcher,
    * @param context for inflate views
    */
   protected void init(Context context) {
-    wrappedEditText = (EditText) LayoutInflater.from(context)
-        .inflate(R.layout.fake_search_view, this, true);
+    LayoutInflater.from(context).inflate(R.layout.fake_search_view, this, true);
+    EditText wrappedEditText = (EditText) findViewById(R.id.wrapped_search);
     wrappedEditText.addTextChangedListener(this);
     wrappedEditText.setOnEditorActionListener(this);
   }

--- a/FakeSearchView/app/src/main/java/com/github/leonardoxh/fakesearchview/FakeSearchView.java
+++ b/FakeSearchView/app/src/main/java/com/github/leonardoxh/fakesearchview/FakeSearchView.java
@@ -120,7 +120,7 @@ public class FakeSearchView extends FrameLayout implements TextWatcher,
    */
   protected void init(Context context) {
     LayoutInflater.from(context).inflate(R.layout.fake_search_view, this, true);
-    EditText wrappedEditText = (EditText) findViewById(R.id.wrapped_search);
+    wrappedEditText = (EditText) findViewById(R.id.wrapped_search);
     wrappedEditText.addTextChangedListener(this);
     wrappedEditText.setOnEditorActionListener(this);
   }


### PR DESCRIPTION
With `AppCompat` v. 22.1.0 you cannot cast result of inflation into self to another view.
